### PR TITLE
Use "absolute_url": True

### DIFF
--- a/nbdatasette.py
+++ b/nbdatasette.py
@@ -13,7 +13,7 @@ def setup_datasette():
             "base_url:{base_url}datasette/",
             dbpath,
         ],
-        "absolute_url": False,
+        "absolute_url": True,
         # The following needs a the labextension installing.
         # eg in postBuild: jupyter labextension install jupyterlab-server-proxy
         "launcher_entry": {


### PR DESCRIPTION
In https://github.com/simonw/datasette/issues/712 it was pointed out that some of the URLs were not working correctly - in particular things like the "suggest facets" link.

After some investigation I found that setting `"absolute_url": True` fixes that bug - and no longer results in an infinite HTTP redirect as it did prior to the `base_url` work.