### PR TITLE
Refactor & publish to PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
-# jupyterserverproxy-datasette-demo
+# jupyter-datasette-proxy
 
-Using datasette with Jupyter Server Proxy.
+Using [datasette](https://datasette.io/) in JupyterHub or Binder with
+[jupyter-server-proxy](https://github.com/jupyterhub/jupyter-server-proxy)
 
 Launch into notebook interface (run `datasette` from the notebook `New` menu): [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/psychemedia/jupyterserverproxy-datasette-demo/master)
 
 Launch directly into datasette: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/psychemedia/jupyterserverproxy-datasette-demo/master?urlpath=datasette)
 
-The `datasette` port is assigned dynamically, although a known port could be specified if datasette is used to provide an API. (But in a notebook context that probably doesn't make sense? You could just as easilu call directly on the SQLite3 db.)
+The `datasette` port is assigned dynamically, although a known port could be specified if datasette is used to provide an API.
 
+## Installation
 
+You can install from PyPI:
+
+```bash
+pip install jupyter-datasette-proxy
+```
+
+This will also bring in datasette.

--- a/jupyter_datasette_proxy.py
+++ b/jupyter_datasette_proxy.py
@@ -8,10 +8,8 @@ def setup_datasette():
             "serve",
             "-p",
             "{port}",
-            "--config",
+            "--setting",
             "base_url:{base_url}datasette/",
-            "-d",
-            os.environ["HOME"]
         ],
         "absolute_url": True,
         # The following needs a the labextension installing.

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,24 @@
 import setuptools
 
+with open("README.md", encoding="utf8") as f:
+    readme = f.read()
+
 setuptools.setup(
-  name="jupyter-datsette-server",
+  name="jupyter-datasette-proxy",
+  version="1.0",
   # py_modules rather than packages, since we only have 1 file
   py_modules=['nbdatasette'],
+  install_requires=[
+    'datasette',
+    'jupyter-server-proxy'
+  ],
+  description="Run datasette on JupyterHub with jupyter-server-proxy",
+  long_description=readme,
+  long_description_content_type="text/markdown",
   entry_points={
       'jupyter_serverproxy_servers': [
           #path = module:entry_function
-          'datasette = nbdatasette:setup_datasette',
+          'datasette = jupyter_datasette_proxy:setup_datasette',
       ]
   },
 )


### PR DESCRIPTION
- Naming convention fits better with other helper packages
  like this
- Depend on jupyter-server-proxy and datasette
- Use --setting instead of --config, as --config is deprecated
- Don't pass -d, instead it'll just start on whatever the cwd of
  the notebook process is. This matches other proxy helpers
- Add to README
- Set version to 1.0
- Populate long_description in setup.py
- I've published this to PyPI - https://pypi.org/project/jupyter-datasette-proxy/